### PR TITLE
Bugfix in ScaledLinearFuncOp

### DIFF
--- a/src/linpde_gp/linfuncops/_arithmetic.py
+++ b/src/linpde_gp/linfuncops/_arithmetic.py
@@ -46,7 +46,7 @@ class ScaledLinearFunctionOperator(LinearFunctionOperator):
     def __rmul__(self, other) -> LinearFunctionOperator:
         if np.ndim(other) == 0:
             return ScaledLinearFunctionOperator(
-                linfuncop=self._linfuncop,
+                self._linfuncop,
                 scalar=np.asarray(other) * self._scalar,
             )
 


### PR DESCRIPTION
`linfuncop` is a positional-only argument, so passing it via `linfuncop=self._linfuncop` breaks.