### PR TITLE
LinFuncOp sum absorption

### DIFF
--- a/src/linpde_gp/linfuncops/_arithmetic.py
+++ b/src/linpde_gp/linfuncops/_arithmetic.py
@@ -87,6 +87,10 @@ class SumLinearFunctionOperator(LinearFunctionOperator):
             output_shapes=(output_domain_shape, output_codomain_shape),
         )
 
+    @property
+    def summands(self) -> tuple[LinearFunctionOperator, ...]:
+        return self._summands
+
     @functools.singledispatchmethod
     def __call__(self, f, /, **kwargs):
         return functools.reduce(
@@ -127,6 +131,6 @@ class CompositeLinearFunctionOperator(LinearFunctionOperator):
         return " @ ".join(repr(linfuncop) for linfuncop in self._linfuncops)
 
 
-@LinearFunctionOperator.__matmul__.register
+@LinearFunctionOperator.__matmul__.register  # pylint: disable=no-member
 def _(self, other: SumLinearFunctionOperator) -> SumLinearFunctionOperator:
-    return SumLinearFunctionOperator(*(self @ summand for summand in other._summands))
+    return SumLinearFunctionOperator(*(self @ summand for summand in other.summands))

--- a/src/linpde_gp/linfuncops/_arithmetic.py
+++ b/src/linpde_gp/linfuncops/_arithmetic.py
@@ -52,6 +52,9 @@ class ScaledLinearFunctionOperator(LinearFunctionOperator):
 
         return super().__rmul__(other)
 
+    def __repr__(self) -> str:
+        return f"{self._scalar} * {self._linfuncop}"
+
 
 class SumLinearFunctionOperator(LinearFunctionOperator):
     def __init__(self, *summands: LinearFunctionOperator) -> None:
@@ -94,6 +97,9 @@ class SumLinearFunctionOperator(LinearFunctionOperator):
     def _(self, randproc: pn.randprocs.RandomProcess, /) -> pn.randprocs.RandomProcess:
         return super().__call__(randproc)
 
+    def __repr__(self):
+        return " + ".join(str(summand) for summand in self._summands)
+
 
 class CompositeLinearFunctionOperator(LinearFunctionOperator):
     def __init__(self, *linfuncops: LinearFunctionOperator) -> None:
@@ -116,3 +122,11 @@ class CompositeLinearFunctionOperator(LinearFunctionOperator):
             reversed(self._linfuncops),
             f,
         )
+
+    def __repr__(self) -> str:
+        return " @ ".join(repr(linfuncop) for linfuncop in self._linfuncops)
+
+
+@LinearFunctionOperator.__matmul__.register
+def _(self, other: SumLinearFunctionOperator) -> SumLinearFunctionOperator:
+    return SumLinearFunctionOperator(*(self @ summand for summand in other._summands))

--- a/src/linpde_gp/linfuncops/_linfuncop.py
+++ b/src/linpde_gp/linfuncops/_linfuncop.py
@@ -127,6 +127,7 @@ class LinearFunctionOperator:
 
         return NotImplemented
 
+    @functools.singledispatchmethod
     def __matmul__(self, other) -> LinearFunctionOperator:
         from ._arithmetic import (  # pylint: disable=import-outside-toplevel
             CompositeLinearFunctionOperator,


### PR DESCRIPTION
Applying a `LinearFunctionOperator` to a `SumLinearFunctionOperator` now "absorbs" the sum, such that the result is again a `SumLinearFunctionOperator` where the summands are `CompositeLinearFunctionOperator`s.

What do you think about this? I've found this to be very useful for the stuff I've been working on recently. But I'm not sure if we *always* want this behavior.